### PR TITLE
Logging to file

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 logging.level.root= WARN
+logging.file = logs.log
 logging.level.pl.put.poznan.transformer= DEBUG
 server.port = 8090


### PR DESCRIPTION
Okazało się (po długiej walce z log4j) że można wykorzystać wewnętrzne mechanizmy springa do logowania i tym sposobem zapisywanie logów do pliku to dodanie jednej linijki do application.properties :+1: 